### PR TITLE
Fix Mac encoding of base64 changelog

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -312,7 +312,7 @@ create_merged_report_file() {
 
   # gen base64 from input
   if [[ $(uname) == "Darwin" ]]; then
-    base64 -i "${source_file}" | tr -d '\n' > "${base64_file}"
+    openssl base64 -in "${source_file}" -out "${base64_file}"
   else
     base64 -w 1000 "${source_file}" > "${base64_file}"
   fi


### PR DESCRIPTION
There was an error with the previous way the base64 file was created resulting in empty changelogs in the DB.

It uses openssl now to successfully encode a base64 file. openssl is native on any Mac.